### PR TITLE
viimeistelty tipin poistaminen ja tagien esitys tippi-listassa

### DIFF
--- a/src/components/TipList.js
+++ b/src/components/TipList.js
@@ -8,7 +8,7 @@ import Button from './Button'
 const TipList = (props) => {
   const { processing, tipdata } = props.tips
 
-  if (processing) {
+  if (processing && tipdata.length === 0) {
     return <Loading />
   }
 
@@ -35,6 +35,14 @@ const TipList = (props) => {
             <div className="tip-content">
               <h3>{tip.title}</h3>
               <a href={tip.url}>{tip.url}</a>
+              <div className="tip-item__meta tip-item__meta--tags">
+                {tip.tags.map((tag, index) => { return (
+                  <span key={`${index}-${tag}-${tip.id}`} className="tag_item">
+                    <span>{tag}</span>
+                    {(index !== tip.tags.length - 1) && <span className="sep">,</span>}
+                  </span>
+                )})}
+              </div>
               <Button
                 onClick={() => deleteTip(tip)}
                 buttonText='Poista'

--- a/src/reducers/tipReducer.js
+++ b/src/reducers/tipReducer.js
@@ -52,12 +52,14 @@ export const removeTip = (id) => {
       type: 'REMOVE_TIP'
     })
 
-    const result = await tipService.remove(id)
+    let result
+    try {
+      result = await tipService.remove(id)
+    } catch (error) {
+      result = error
+    }
 
-    // const result = 200
-    // if (result === 200) {
-
-    if (result.status === 200) {
+    if (result.status === 204) {
       dispatch({
         type: 'REMOVE_SUCCESS',
         data: id


### PR DESCRIPTION
Reducerissa delete-kutsu try-catch -blokin sisällä, jotta virheet saadaan käsiteltyä. Huomaa, että onnistuneen poiston statuskoodi on 204 "no content".

Tippilistassa tipin tag-itemeille tehdään yksilöllinen key tähän hätään tipin id:n, indeksin ja ja tagin nimestä, koska tippi-objektin tageilla ei ole yksilöllistä identifiaatiota kuten id-tunnistetta toistaiseksi. 

Tagit ovat span-elementtien sisällä, jotta niitä voidaan vapaasti tyylitellä ja voidaan liittää esim. onClick-metodi, josta saa valittua tagin suoraan filtteriksi. Separaattori on myös span-elementin sisällä, jotta sitä voidaan vapaasti tyylitellä myös.