### PR TITLE
tagihaku

### DIFF
--- a/src/components/AddTip.js
+++ b/src/components/AddTip.js
@@ -15,7 +15,7 @@ const AddTip = (props) => {
     props.addTip({
       title: title.value.trim(),
       url: url.value.trim(),
-      tags: tags.value.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0)
+      tags: tags.value.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0),
     })
     title.reset()
     url.reset()

--- a/src/components/NoTips.js
+++ b/src/components/NoTips.js
@@ -19,7 +19,7 @@ const NoTips = (props) => {
 
 const mapStateToProps = (state) => {
   return {
-    isSearchActive: state.tips.isSearchActive
+    isSearchActive: state.tips.isSearchActive,
   }
 }
 

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { searchByTerms, removeSearchFilter } from '../reducers/tipReducer'
+import { searchByTerms, searchByTag, removeSearchFilter } from '../reducers/tipReducer'
 import { useField } from '../hooks/index'
 import TextInput from './TextInput'
 import Button from './Button'
@@ -8,24 +8,39 @@ import Button from './Button'
 const SearchForm = (props) => {
 
   const title = useField('text')
+  const tag = useField('text')
 
-  const handleSubmit = (e) => {
+  const handleTitleSearchSubmit = (e) => {
     e.preventDefault()
+    tag.reset()
     props.searchByTerms({
       title: title.value.trim()
     })
   }
 
+  const handleTagSearchSubmit = (e) => {
+    e.preventDefault()
+    title.reset()
+    props.searchByTag({
+      tag: tag.value.trim()
+    })
+  }
+
   const handleReset = () => {
     title.reset()
+    tag.reset()
     props.removeSearchFilter()
   }
 
   return (
     <div className="search-form__wrapper">
-      <form className="search__form" onSubmit={handleSubmit}>
-        <TextInput label='Etsi vinkkejä' inputValue={title} />
+      <form className="search__form search__form--title" onSubmit={handleTitleSearchSubmit}>
+        <TextInput label='Etsi vinkkejä otsikolla' inputValue={title} />
         <Button buttonText='Hae' priority='primary' type='submit' cyDataAttribute='search-by-tip-title' />
+      </form>
+      <form className="search__form search__form--tags" onSubmit={handleTagSearchSubmit}>
+        <TextInput label='Etsi vinkkejä tagilla' inputValue={tag} />
+        <Button buttonText='Hae' priority='primary' type='submit' cyDataAttribute='search-by-tip-tag' />
       </form>
       {props.isSearchActive &&
           <Button
@@ -48,6 +63,7 @@ const mapStateToProps = (state) => {
 
 const connectedSearchForm = connect(mapStateToProps, {
   searchByTerms,
+  searchByTag,
   removeSearchFilter
 })(SearchForm)
 

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -14,7 +14,7 @@ const SearchForm = (props) => {
     e.preventDefault()
     tag.reset()
     props.searchByTerms({
-      title: title.value.trim()
+      title: title.value.trim(),
     })
   }
 
@@ -22,7 +22,7 @@ const SearchForm = (props) => {
     e.preventDefault()
     title.reset()
     props.searchByTag({
-      tag: tag.value.trim()
+      tag: tag.value.trim(),
     })
   }
 
@@ -57,14 +57,14 @@ const SearchForm = (props) => {
 
 const mapStateToProps = (state) => {
   return {
-    isSearchActive: state.tips.isSearchActive
+    isSearchActive: state.tips.isSearchActive,
   }
 }
 
 const connectedSearchForm = connect(mapStateToProps, {
   searchByTerms,
   searchByTag,
-  removeSearchFilter
+  removeSearchFilter,
 })(SearchForm)
 
 export default connectedSearchForm

--- a/src/reducers/tipReducer.js
+++ b/src/reducers/tipReducer.js
@@ -192,7 +192,7 @@ const initialState = {
   tipdata: [],
   processing: true,
   error: null,
-  isSearchActive: false
+  isSearchActive: false,
 }
 
 const tipReducer = (state = initialState, action) => {
@@ -200,7 +200,7 @@ const tipReducer = (state = initialState, action) => {
     case 'INIT_GET_TIPS':
       return {
         ...state,
-        processing: true
+        processing: true,
       }
     case 'GET_TIPS_SUCCESS':
       return {
@@ -219,7 +219,7 @@ const tipReducer = (state = initialState, action) => {
         ...state,
         tipdata: state.tipdata.concat(action.data),
         processing: false,
-        error: null
+        error: null,
       }
     case 'INIT_REMOVE_TIP':
       return {
@@ -237,7 +237,7 @@ const tipReducer = (state = initialState, action) => {
       return {
         ...state,
         processing: true,
-        isSearchActive: true
+        isSearchActive: true,
       }
     case 'SEARCH_TIPS_SUCCESS':
       return {
@@ -252,7 +252,7 @@ const tipReducer = (state = initialState, action) => {
         tipdata: action.data,
         processing: false,
         error: null,
-        isSearchActive: false
+        isSearchActive: false,
       }
     case 'INIT_READ_TIP':
       return {

--- a/src/reducers/tipReducer.js
+++ b/src/reducers/tipReducer.js
@@ -59,6 +59,41 @@ export const searchByTerms = (termData) => {
   }
 }
 
+export const searchByTag = (termData) => {
+  return async (dispatch) => {
+    dispatch({
+      type: 'INIT_SEARCH_TIPS',
+    })
+
+    let result
+
+    try {
+      if (termData.tag.length === 0) {
+        result = await tipService.getAll()
+      } else {
+        result = await tipService.getByTag(termData.tag)
+      }
+    } catch (error) {
+      result = error
+    }
+
+    if (result.status === 200) {
+      const formattedTips = result.data.map(formatTip)
+
+      dispatch({
+        type: 'SEARCH_TIPS_SUCCESS',
+        data: formattedTips,
+      })
+    } else {
+      dispatch({
+        type: 'ACTION_FAIL',
+        data: result,
+      })
+    }
+  }
+}
+
+
 export const removeSearchFilter = () => {
   return async (dispatch) => {
     dispatch({

--- a/src/services/tips.js
+++ b/src/services/tips.js
@@ -1,29 +1,35 @@
 import axios from 'axios'
-const baseUrl = '/api/tips'
+const baseUrl = '/api'
 
 const getAll = async () => {
-  const response = await axios.get(baseUrl)
+  const response = await axios.get(`${baseUrl}/tips`)
   return response
 }
 
 const getByTitle = async title => {
-  const response = await axios.get(`${baseUrl}/title/${title}`)
+  const response = await axios.get(`${baseUrl}/tips/title/${title}`)
+  return response
+}
+
+const getByTag = async tag => {
+  console.log(`${baseUrl}/tags/${tag}`)
+  const response = await axios.get(`${baseUrl}/tags/${tag}`)
   return response
 }
 
 const create = async newObject => {
-  const response = await axios.post(baseUrl, newObject)
+  const response = await axios.post(`${baseUrl}/tips`, newObject)
   return response
 }
 
 const remove = async id => {
-  const response = await axios.delete(`${baseUrl}/${id}`)
+  const response = await axios.delete(`${baseUrl}/tips/${id}`)
   return response
 }
 
 const read = async id => {
-  const response = await axios.post(`${baseUrl}/${id}/read`)
+  const response = await axios.post(`${baseUrl}/tips/${id}/read`)
   return response
 }
 
-export default { getAll, getByTitle, create, remove, read }
+export default { getAll, getByTitle, getByTag, create, remove, read }

--- a/src/store.js
+++ b/src/store.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk'
 import tipReducer from './reducers/tipReducer'
 
 const reducer = combineReducers({
-  tips: tipReducer
+  tips: tipReducer,
 })
 
 const store = createStore(reducer, applyMiddleware(thunk))


### PR DESCRIPTION
Tagihaku lisätty. Ei kauhean käyttäjäystävällinen toteutus, eikä todellakaan elegantti tekninen toteutus, mutta ajattelin, että ehdin tämmöisen vielä pyöräyttämään näytille tässä nopeasti.

Jouduin muuttamaan tipservicen baseurlia, koska tagit haetaan routella /api/tags/<tagname> ja tipsit haetaan /api/tips/* routeista. 

Tagihaun endpointti palauttaa 500 server erroria jos hakee tagilla jota ei ole. Tämä nyt käsitelty try-catch -blokissa tipreducerin searchByTag-actionissa. 

Jooh, eli ei mikään timantti, mutta ajaa asian.